### PR TITLE
fix: set babel-runtime as dependency instead of devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/webdriverio/wdio-spec-reporter#readme",
   "dependencies": {
+    "babel-runtime": "^5.8.25",
     "humanize-duration": "^3.9.0"
   },
   "devDependencies": {
@@ -38,7 +39,6 @@
     "babel-eslint": "^4.1.7",
     "babel-istanbul": "^0.4.1",
     "babel-plugin-rewire": "^0.1.22",
-    "babel-runtime": "^5.8.25",
     "codeclimate-test-reporter": "^0.1.1",
     "eslint": "^1.4.1",
     "eslint-config-standard": "^4.3.2",


### PR DESCRIPTION
The import of the build/reporter.js couldn't be satisfied since babel-runtime was not installed, because it was not defined in dependencies