### PR TITLE
Wdio spec reporter issues 11

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -72,8 +72,8 @@ class SpecReporter extends events.EventEmitter {
         })
     }
 
-    indent (cid, specTitle) {
-        const indents = this.suiteIndents[cid] && this.suiteIndents[cid][specTitle] || -1
+    indent (cid, specUid) {
+        const indents = this.suiteIndents[cid] && this.suiteIndents[cid][specUid] || -1
         return indents < 0 ? '' : Array(indents).join('  ')
     }
 
@@ -147,13 +147,15 @@ class SpecReporter extends events.EventEmitter {
     getResultList (cid, suites, preface = '') {
         let output = ''
 
-        for (const specTitle in suites) {
-            const spec = suites[specTitle]
-            const indent = this.indent(cid, specTitle)
+        for (const specUid in suites) {
+            const spec = suites[specUid]
+            const indent = this.indent(cid, specUid)
+            const specTitle = suites[specUid].title
             output += `${preface}   ${indent}${specTitle}\n`
 
-            for (const testTitle in spec.tests) {
-                const test = spec.tests[testTitle]
+            for (const testUid in spec.tests) {
+                const test = spec.tests[testUid]
+                const testTitle = spec.tests[testUid].title
 
                 if (test.state === '') {
                     continue

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1,20 +1,50 @@
 export const SUITE = {
-    'some foobar test': {
+    'some foobar test1': {
+        uid: 'some foobar test1',
+        title: 'some foobar test',
         tests: {
-            'foo': { state: 'pass' },
-            'bar': { state: 'pending' }
+            'foo1': {
+                title: 'foo',
+                uid: 'foo1',
+                state: 'pass'
+            },
+            'bar2': {
+                title: 'bar',
+                uid: 'bar2',
+                state: 'pending'
+            }
         }
     },
-    'some other foobar test': {
+    'some other foobar test2': {
+        uid: 'some other foobar test2',
+        title: 'some other foobar test',
         tests: {
-            'that is a test': { state: 'pass' },
-            'and another test': { state: 'fail' }
+            'that is a test4': {
+                uid: 'that is a test4',
+                title: 'that is a test',
+                state: 'pass'
+            },
+            'and another test': {
+                uid: 'and another test5',
+                title: 'and another test',
+                state: 'fail'
+            }
         }
     },
-    'some spec title': {
+    'some spec title3': {
+        uid: 'some spec title3',
+        title: 'some spec title',
         tests: {
-            'some last test': { state: 'fail' },
-            'really last': { state: 'fail' }
+            'some last test6': {
+                uid: 'some last test6',
+                title: 'some last test',
+                state: 'fail'
+            },
+            'really last7': {
+                uid: 'really last7',
+                title: 'really last',
+                state: 'fail'
+            }
         }
     }
 }


### PR DESCRIPTION
**Please note:** this PR is about fixing issue #11 please refer to that issue for more details.

The problem as described in the issue is that the title is being used to identify suite/specs & tests when rendering the report. This results in items with the same name being displayed only once. 

To resolve this I added a UID to each library that can be used to identify the item as a unique item. This Resolves the issue and will make sure all items are always displayed when rendering the report.

This **is** a breaking change! Since we need now rely on the UID implementation of WDIO & the testing libraries.