### PR TITLE
Add a summary to the end when more than one spec was run

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -18,7 +18,6 @@ class SpecReporter extends events.EventEmitter {
         super()
 
         this.baseReporter = baseReporter
-        const { epilogue } = this.baseReporter
         this.config = config
         this.options = options
         this.shortEnglishHumanizer = humanizeDuration.humanizer({
@@ -72,15 +71,8 @@ class SpecReporter extends events.EventEmitter {
             this.printSuiteResult(runner)
         })
 
-        this.on('end', () => {
-            var specCount = Object.keys(baseReporter.stats.runners).length
-
-            if (specCount > 1) { // Show summary if more then one spec was run
-                console.log('\n\n==================================================================\n')
-                console.log('Number of specs:', specCount)
-                epilogue.call(baseReporter)
-                console.log()
-            }
+        this.on('end', function (runner) {
+            this.printSuitesSummary(runner)
         })
     }
 
@@ -288,6 +280,23 @@ class SpecReporter extends events.EventEmitter {
 
     printSuiteResult (runner) {
         console.log(this.getSuiteResult(runner))
+    }
+
+    getSuitesSummary (runner) {
+        const specCount = Object.keys(this.baseReporter.stats.runners).length
+        const epilogue = this.baseReporter.epilogue
+        let output = ''
+
+        if (specCount > 1) { // Show summary if more then one spec was run
+            output += '\n\n==================================================================\n'
+            output += 'Number of specs: ' + specCount
+            output += epilogue.call(this.baseReporter)
+        }
+        return output
+    }
+
+    printSuitesSummary (runner) {
+        console.log(this.getSuitesSummary(runner))
     }
 }
 

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -18,6 +18,7 @@ class SpecReporter extends events.EventEmitter {
         super()
 
         this.baseReporter = baseReporter
+        const { epilogue } = this.baseReporter
         this.config = config
         this.options = options
         this.shortEnglishHumanizer = humanizeDuration.humanizer({
@@ -69,6 +70,17 @@ class SpecReporter extends events.EventEmitter {
 
         this.on('runner:end', function (runner) {
             this.printSuiteResult(runner)
+        })
+
+        this.on('end', () => {
+            var specCount = Object.keys(baseReporter.stats.runners).length
+
+            if (specCount > 1) { // Show summary if more then one spec was run
+                console.log('\n\n==================================================================\n')
+                console.log('Number of specs:', specCount)
+                epilogue.call(baseReporter)
+                console.log()
+            }
         })
     }
 


### PR DESCRIPTION
Add a summary after the last spec. Especially handy to get a quick overview when you've run a lot of tests.