### PR TITLE
Make getBrowserCombo compatible with Browserstack browser and platfor…

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -119,9 +119,9 @@ class SpecReporter extends events.EventEmitter {
 
     getBrowserCombo (caps, verbose = true) {
         const device = caps.deviceName
-        const browser = caps.browserName
-        const version = caps.version || caps.platformVersion
-        const platform = caps.platform || caps.platformName
+        const browser = caps.browserName || caps.browser
+        const version = caps.version || caps.platformVersion || caps.browser_version
+        const platform = caps.os ? (caps.os + ' ' + caps.os_version) : (caps.platform || caps.platformName)
 
         /**
          * mobile capabilities

--- a/test/reporter.spec.js
+++ b/test/reporter.spec.js
@@ -122,6 +122,24 @@ describe('spec reporter', () => {
                 browserName: 'Safari'
             }, false).should.be.equal('iPhone 6 Plus iOS 9.2')
         })
+
+        it('should return verbose desktop combo when using BrowserStack capabilities', () => {
+            reporter.getBrowserCombo({
+                browser: 'Chrome',
+                browser_version: 50,
+                os: 'Windows',
+                os_version: '10'
+            }).should.be.equal('Chrome (v50) on Windows 10')
+        })
+
+        it('should return preface desktop combo when using BrowserStack capabilities', () => {
+            reporter.getBrowserCombo({
+                browser: 'Chrome',
+                browser_version: 50,
+                os: 'Windows',
+                os_version: '10'
+            }, false).should.be.equal('Chrome 50 Windows 10')
+        })
     })
 
     describe('getResultList', () => {


### PR DESCRIPTION
…m keynames

Browserstack does not use the official selenium capability properties (See https://github.com/webdriverio/wdio-spec-reporter/issues/9 ). This PR fixes the reporting when running tests on Browserstack. The official capability properties are still supported.