### PR TITLE
Fix suite indents

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -48,7 +48,7 @@ class SpecReporter extends events.EventEmitter {
         })
 
         this.on('suite:start', function (suite) {
-            this.suiteIndents[suite.cid][suite.title] = ++this.indents[suite.cid]
+            this.suiteIndents[suite.cid][suite.uid] = ++this.indents[suite.cid]
         })
 
         this.on('test:pending', function (test) {


### PR DESCRIPTION
The suite indents are accidentally keyed with suite title.
One should use suite uid instead.

This should fix #19, fix #22, fix #24