### PR TITLE
Fix issue #68

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -15,9 +15,8 @@ const DURATION_OPTIONS = {
  * @api public
  */
 class SpecReporter extends events.EventEmitter {
-    constructor (baseReporter, config, options = {}) {
+    constructor (baseReporter, config = {}, options = {}) {
         super()
-
         this.chalk = chalk
         this.baseReporter = baseReporter
         this.config = config
@@ -103,21 +102,23 @@ class SpecReporter extends events.EventEmitter {
         return symbol
     }
 
-    getColor (state) {
+    getColor (state, coloredLogs) {
         let color = null // in case of an unknown state
 
-        switch (state) {
-        case 'pass':
-        case 'passing':
-            color = 'green'
-            break
-        case 'pending':
-            color = 'cyan'
-            break
-        case 'fail':
-        case 'failing':
-            color = 'red'
-            break
+        if (coloredLogs !== false) {
+            switch (state) {
+            case 'pass':
+            case 'passing':
+                color = 'green'
+                break
+            case 'pending':
+                color = 'cyan'
+                break
+            case 'fail':
+            case 'failing':
+                color = 'red'
+                break
+            }
         }
 
         return color
@@ -177,7 +178,7 @@ class SpecReporter extends events.EventEmitter {
 
                 output += preface
                 output += '   ' + indent
-                output += this.chalk[this.getColor(test.state)](this.getSymbol(test.state))
+                output += this.chalk[this.getColor(test.state, this.config.coloredLogs)](this.getSymbol(test.state))
                 output += ' ' + testTitle + '\n'
             }
 
@@ -210,8 +211,8 @@ class SpecReporter extends events.EventEmitter {
             }
 
             output += preface + ' '
-            output += this.chalk[this.getColor(state)](testCount)
-            output += ' ' + this.chalk[this.getColor(state)](state)
+            output += this.chalk[this.getColor(state, this.config.coloredLogs)](testCount)
+            output += ' ' + this.chalk[this.getColor(state, this.config.coloredLogs)](state)
             output += testDuration
             output += '\n'
             displayedDuration = true

--- a/package-lock.json
+++ b/package-lock.json
@@ -4986,9 +4986,9 @@
       }
     },
     "mocha": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
-      "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.0.tgz",
+      "integrity": "sha512-ukB2dF+u4aeJjc6IGtPNnJXfeby5d4ZqySlIBT0OEyva/DrMjVm5HkQxKnHDLKEfEQBsEnwTg9HHhtPHJdTd8w==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",

--- a/test/reporter.spec.js
+++ b/test/reporter.spec.js
@@ -152,6 +152,16 @@ describe('spec reporter', () => {
             reporter.getColor('failing').should.be.equal('red');
             (reporter.getColor('foobar') === null).should.be.true()
         })
+
+        it('should return the right symbol when using non default coloredLogs configuration', () => {
+            (reporter.getColor('pass', false) === null).should.be.true();
+            (reporter.getColor('passing', false) === null).should.be.true();
+            (reporter.getColor('pending', false) === null).should.be.true();
+            (reporter.getColor('fail', false) === null).should.be.true();
+            (reporter.getColor('fail', false) === null).should.be.true();
+            (reporter.getColor('failing', false) === null).should.be.true();
+            (reporter.getColor('foobar', false) === null).should.be.true()
+        })
     })
 
     describe('getBrowserCombo', () => {


### PR DESCRIPTION
CLA Signed. Note that this fix won't actually work since WebDriverIO itself needs a fix on the configuration generator. I haven't gone too much into details, but looks like `coloredLogs` flag is always being set to `true` in the configuration object passed to the reporter.