### PR TITLE
Clear results + failures in between watch mode runs

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -296,7 +296,9 @@ class SpecReporter extends events.EventEmitter {
         output += this.getResultList(cid, spec.suites, preface)
         output += `${preface}\n`
         output += this.getSummary(this.results[cid], spec._duration, preface)
+        this.results[cid] = { passing: 0, pending: 0, failing: 0 }
         output += this.getFailureList(failures, preface)
+        stats.failures = []
         output += this.getJobLink(results, preface)
         output += `${preface}\n`
         return output


### PR DESCRIPTION
Clears results and failures between test runs in watch mode. Issue referenced here on webdriverio project: https://github.com/webdriverio/webdriverio/issues/1976.