### PR TITLE
Watch mode clear results

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -295,10 +295,10 @@ class SpecReporter extends events.EventEmitter {
         output += `${preface}\n`
         output += this.getResultList(cid, spec.suites, preface)
         output += `${preface}\n`
-        output += this.getSummary(this.results[cid], spec._duration, preface);
-        this.results[cid] = { passing: 0, pending: 0, failing: 0 };
-        output += this.getFailureList(failures, preface);
-        stats.failures = [];
+        output += this.getSummary(this.results[cid], spec._duration, preface)
+        this.results[cid] = { passing: 0, pending: 0, failing: 0 }
+        output += this.getFailureList(failures, preface)
+        stats.failures = []
         output += this.getJobLink(results, preface)
         output += `${preface}\n`
         return output

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -295,8 +295,10 @@ class SpecReporter extends events.EventEmitter {
         output += `${preface}\n`
         output += this.getResultList(cid, spec.suites, preface)
         output += `${preface}\n`
-        output += this.getSummary(this.results[cid], spec._duration, preface)
-        output += this.getFailureList(failures, preface)
+        output += this.getSummary(this.results[cid], spec._duration, preface);
+        this.results[cid] = { passing: 0, pending: 0, failing: 0 };
+        output += this.getFailureList(failures, preface);
+        stats.failures = [];
         output += this.getJobLink(results, preface)
         output += `${preface}\n`
         return output


### PR DESCRIPTION
Clears results and failures between test runs in watch mode. Issue referenced here on webdriverio project: [#1976](https://github.com/webdriverio/webdriverio/issues/1976). It seems the problem with [#1976](https://github.com/webdriverio/webdriverio/issues/1976), wasn't that the tests were being re-run, but that the spec reporter wasn't clearing the results after each run.