### PR TITLE
Output saucelabs test url if using wdio-sauce-service

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -245,7 +245,7 @@ class SpecReporter extends events.EventEmitter {
         }
 
         let output = ''
-        if (results.config.host.indexOf('saucelabs.com') > -1) {
+        if (results.config.host.indexOf('saucelabs.com') > -1 || results.config.sauceConnect === true) {
             output += `${preface.trim()}\n`
             output += `${preface} Check out job at https://saucelabs.com/tests/${results.sessionID}\n`
             return output


### PR DESCRIPTION
Fix for https://github.com/webdriverio/wdio-sauce-service/issues/47

The error seems to occur because the check in reporter looks for config.host to be saucelabs.com, but wdio-sauce-service sets config.host to localhost at https://github.com/webdriverio/wdio-sauce-service/blob/master/lib/sauce-launch-service.js#L18

I can fix it there instead but I don't know the ramifications of that across all projects.