### PR TITLE
Adding a new line character to output

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -274,7 +274,7 @@ class SpecReporter extends events.EventEmitter {
         this.errorCount = 0
         let output = ''
 
-        output += '------------------------------------------------------------------\n'
+        output += '\n------------------------------------------------------------------\n'
 
         /**
          * won't be available when running multiremote tests


### PR DESCRIPTION
Adding a new line character for the output field. Adding this so that the Output always starts from a new line. 

Problem: 
Facing an issue of output starting immediately after dot reporter when using multiple reporters (dot spec)together. 